### PR TITLE
Update info about wolfSSL

### DIFF
--- a/cryptography.md
+++ b/cryptography.md
@@ -27,7 +27,7 @@ These trackers are a crowdsourced effort; please contribute by updating the stat
 | OpenSSL | [>=3.5](https://openssl-library.org/post/2025-04-08-openssl-35-final-release/) | 🟢 Ready | C | | Native support for ML-KEM-512/768/1024, ML-DSA and SLH-DSA was introduced in [OpenSSL 3.5](https://openssl.foundation/news/the-features-of-3-5-post-quantum-cryptography). Older versions require the third-party Open Quantum Safe (OQS) provider |
 | PyCa/cryptography |	N/A |	🔴 Not Supported | Python | None | The standard Python cryptography package does not yet have native support. Users typically use wrappers like pyoqs or wolfcrypt-py |
 | ring |	N/A |	🔴 Not Supported	| Rust |	None	| The ring crate does not support ML-KEM. Rust developers often use ml-kem (from the RustCrypto project) or aws-lc-rs for PQC support |
-| wolfSSL	| >=v5.0.0 (via liboqs), v? for native support |	🟢 Ready | C | ML-KEM, ML-DSA | 	|
+| wolfSSL	| >=v5.8.0  |	🟢 Ready | C | ML-KEM, ML-DSA, SLH-DSA, LMS/HSS, XMSS/XMSS^MT | Initial support for PQC was introduced in v5.0.0 using liboqs. Native PQC implementations were introduced in v5.7.0, and support for liboqs was deprecated in [February 2025](https://www.wolfssl.com/deprecation-notice-liboqs-integration/)	|
 
 
 Status: 🟢 Ready / 🟡 In Progress / 🔴 Not Started


### PR DESCRIPTION
A small contribution after the first meeting and having a quick look at the repo.

I used to maintain a wolfssl-pqc PKGBUILD for Arch Linux compiled against liboqs. I requested it to be deleted already back in [December 2025](https://lists.archlinux.org/archives/list/aur-requests@lists.archlinux.org/message/JB2ELRYMU7KHVTEKFIUSQNYISF6XSFD2/) since it was clear that wolfSSL was not interested in supporting the integration with [liboqs](https://www.wolfssl.com/deprecation-notice-liboqs-integration/) anymore.

I suggest we keep it simple and we just mention the version since they have their native PQC implementations. Apart from ML-KEM and ML-DSA, wolfSSL also supports SLH-DSA and the two families of stateful hash-based signatures (including their multi-tree variants). To give credit to their early support for PQC, I added a small note saying that they supported integration with liboqs since version 5.0.0. Hope that works. Open to suggestions.