### PR TITLE
Refine browser PQC readiness entries and references

### DIFF
--- a/web-browsers.md
+++ b/web-browsers.md
@@ -12,7 +12,9 @@ These trackers are a crowdsourced effort; please contribute by updating the stat
 | Microsoft Edge | >=131 | 🟢 Ready | Windows, macOS, Linux, Android, iOS | ML-KEM (Kyber) | Based on Chromium, follows Chrome's PQC implementation timeline. Enabled ML-KEM-768 hybrid key exchange in version 131. |
 | Brave | >=1.73 | 🟢 Ready | Windows, macOS, Linux, Android, iOS | ML-KEM (Kyber) | Based on Chromium, enabled ML-KEM-768 hybrid key exchange. Follows upstream Chromium PQC implementation. |
 | Opera | >=117 | 🟢 Ready | Windows, macOS, Linux, Android | ML-KEM (Kyber) | Based on Chromium, supports ML-KEM-768 hybrid key exchange following upstream implementation. |
-| Mozilla Firefox | N/A | 🔴 Not Supported | Windows, macOS, Linux, Android, iOS | None | Firefox does not yet have native PQC support in TLS. Uses NSS for cryptography which lacks PQC implementation. Tracking in https://bugzilla.mozilla.org/show_bug.cgi?id=1857217 |
+| Mozilla Firefox Desktop | >=132 | Ready | Windows, macOS, Linux | mlkem768x25519 / X25519MLKEM768 | Enabled by default for TLS 1.3 on desktop starting in Firefox 132. References: https://www.mozilla.org/en-US/firefox/132.0/releasenotes/ and https://bugzilla.mozilla.org/show_bug.cgi?id=1919097 |
+| Mozilla Firefox Android | >=145 | Ready | Android | mlkem768x25519 / X25519MLKEM768 | Firefox for Android 145 added ML-KEM support for TLS 1.3 and HTTP/3. Reference: https://www.mozilla.org/en-US/firefox/android/145.0/releasenotes/ |
+| Mozilla Firefox iOS | Unknown / Limited | Needs Validation | iOS | Unknown | Firefox on iOS relies on Apple WebKit networking constraints, so PQC readiness should be validated separately. |
 | Apple Safari | N/A | 🔴 Not Supported | macOS, iOS, iPadOS | None | Safari does not yet have announced PQC support in TLS. Apple has not publicly disclosed PQC implementation timeline. |
 
 Status: 🟢 Ready / 🟡 In Progress / 🔴 Not Started

--- a/web-browsers.md
+++ b/web-browsers.md
@@ -8,16 +8,16 @@ These trackers are a crowdsourced effort; please contribute by updating the stat
 
 | Browser | Version | Status | Platform | Supported Algorithms | Notes |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| Google Chrome | >=131 | Ready | Windows, macOS, Linux, Android, iOS | ML-KEM (Kyber) | Chrome enabled ML-KEM-768 hybrid key exchange by default starting in Chrome 131. Uses BoringSSL which supports ML-KEM. Reference: https://blog.chromium.org/2024/09/building-quantum-resistant-encryption.html |
-| Microsoft Edge | >=131 | Ready | Windows, macOS, Linux, Android, iOS | ML-KEM (Kyber) | Based on Chromium, follows Chrome's PQC implementation timeline. Enabled ML-KEM-768 hybrid key exchange in version 131. |
-| Brave | >=1.73 | Ready | Windows, macOS, Linux, Android, iOS | ML-KEM (Kyber) | Based on Chromium, enabled ML-KEM-768 hybrid key exchange. Follows upstream Chromium PQC implementation. |
-| Opera | >=117 | Ready | Windows, macOS, Linux, Android | ML-KEM (Kyber) | Based on Chromium, supports ML-KEM-768 hybrid key exchange following upstream implementation. |
-| Mozilla Firefox Desktop | >=132 | Ready | Windows, macOS, Linux | mlkem768x25519 / X25519MLKEM768 | Enabled by default for TLS 1.3 on desktop starting in Firefox 132. References: https://www.mozilla.org/en-US/firefox/132.0/releasenotes/ and https://bugzilla.mozilla.org/show_bug.cgi?id=1919097 |
-| Mozilla Firefox Android | >=145 | Ready | Android | mlkem768x25519 / X25519MLKEM768 | Firefox for Android 145 added ML-KEM support for TLS 1.3 and HTTP/3. Reference: https://www.mozilla.org/en-US/firefox/android/145.0/releasenotes/ |
+| Google Chrome | >=131 | Ready | Windows, macOS, Linux, Android, iOS | ML-KEM-768 hybrid | Chrome enabled ML-KEM-768 hybrid key exchange by default starting in Chrome 131. Uses BoringSSL which supports ML-KEM. Reference: https://blog.chromium.org/2024/09/building-quantum-resistant-encryption.html |
+| Microsoft Edge | >=131 | Ready | Windows, macOS, Linux, Android, iOS | ML-KEM-768 hybrid | Based on Chromium, follows Chrome's PQC implementation timeline. Enabled ML-KEM-768 hybrid key exchange in version 131. |
+| Brave | >=1.73 | Ready | Windows, macOS, Linux, Android, iOS | ML-KEM-768 hybrid | Based on Chromium, enabled ML-KEM-768 hybrid key exchange. Follows upstream Chromium PQC implementation. |
+| Opera | >=117 | Ready | Windows, macOS, Linux, Android | ML-KEM-768 hybrid | Based on Chromium, supports ML-KEM-768 hybrid key exchange following upstream implementation. |
+| Mozilla Firefox Desktop | >=132 | Ready | Windows, macOS, Linux | ML-KEM-768 hybrid (X25519MLKEM768) | Enabled by default for TLS 1.3 on desktop starting in Firefox 132. References: https://www.mozilla.org/en-US/firefox/132.0/releasenotes/ and https://bugzilla.mozilla.org/show_bug.cgi?id=1919097 |
+| Mozilla Firefox Android | >=145 | Ready | Android | ML-KEM-768 hybrid (X25519MLKEM768) | Firefox for Android 145 added ML-KEM support for TLS 1.3 and HTTP/3. Reference: https://www.mozilla.org/en-US/firefox/android/145.0/releasenotes/ |
 | Mozilla Firefox iOS | Unknown / Limited | Needs Validation | iOS | Unknown | Firefox on iOS relies on Apple WebKit networking constraints, so PQC readiness should be validated separately. |
-| Apple Safari | N/A | Not Supported | macOS, iOS, iPadOS | None | Safari does not yet have announced PQC support in TLS. Apple has not publicly disclosed PQC implementation timeline. |
+| Apple Safari | N/A | Unknown / No Public TLS PQC Support | macOS, iOS, iPadOS | Unknown | Apple has not publicly disclosed general availability of PQC support for Safari TLS connections. |
 
-Status: Ready / In Progress / Not Started
+Status: Ready / In Progress / Not Started / Needs Validation
 
 ## How to Contribute
 
@@ -29,4 +29,5 @@ Status: Ready / In Progress / Not Started
 
 * All linked information should point to an official repository or technical documentation.
 * For browsers, please include version numbers where PQC support was introduced.
+* Distinguish between experimental support, available support, and enabled-by-default support where possible.
 * Focus on TLS/HTTPS connection security rather than other cryptographic features.

--- a/web-browsers.md
+++ b/web-browsers.md
@@ -8,23 +8,25 @@ These trackers are a crowdsourced effort; please contribute by updating the stat
 
 | Browser | Version | Status | Platform | Supported Algorithms | Notes |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| Google Chrome | >=131 | 🟢 Ready | Windows, macOS, Linux, Android, iOS | ML-KEM (Kyber) | Chrome enabled ML-KEM-768 (X25519Kyber768) hybrid key exchange by default starting in Chrome 131. Uses BoringSSL which supports ML-KEM. https://blog.chromium.org/2024/09/building-quantum-resistant-encryption.html |
-| Microsoft Edge | >=131 | 🟢 Ready | Windows, macOS, Linux, Android, iOS | ML-KEM (Kyber) | Based on Chromium, follows Chrome's PQC implementation timeline. Enabled ML-KEM-768 hybrid key exchange in version 131. |
-| Brave | >=1.73 | 🟢 Ready | Windows, macOS, Linux, Android, iOS | ML-KEM (Kyber) | Based on Chromium, enabled ML-KEM-768 hybrid key exchange. Follows upstream Chromium PQC implementation. |
-| Opera | >=117 | 🟢 Ready | Windows, macOS, Linux, Android | ML-KEM (Kyber) | Based on Chromium, supports ML-KEM-768 hybrid key exchange following upstream implementation. |
-| Mozilla Firefox Desktop | >=132 | 🟢 Ready | Windows, macOS, Linux | mlkem768x25519 / X25519MLKEM768 | Enabled by default for TLS 1.3 on desktop starting in Firefox 132. References: https://www.mozilla.org/en-US/firefox/132.0/releasenotes/ and https://bugzilla.mozilla.org/show_bug.cgi?id=1919097 |
-| Mozilla Firefox Android | >=145 | 🟢 Ready | Android | mlkem768x25519 / X25519MLKEM768 | Firefox for Android 145 added ML-KEM support for TLS 1.3 and HTTP/3. Reference: https://www.mozilla.org/en-US/firefox/android/145.0/releasenotes/ |
+| Google Chrome | >=131 | Ready | Windows, macOS, Linux, Android, iOS | ML-KEM (Kyber) | Chrome enabled ML-KEM-768 hybrid key exchange by default starting in Chrome 131. Uses BoringSSL which supports ML-KEM. Reference: https://blog.chromium.org/2024/09/building-quantum-resistant-encryption.html |
+| Microsoft Edge | >=131 | Ready | Windows, macOS, Linux, Android, iOS | ML-KEM (Kyber) | Based on Chromium, follows Chrome's PQC implementation timeline. Enabled ML-KEM-768 hybrid key exchange in version 131. |
+| Brave | >=1.73 | Ready | Windows, macOS, Linux, Android, iOS | ML-KEM (Kyber) | Based on Chromium, enabled ML-KEM-768 hybrid key exchange. Follows upstream Chromium PQC implementation. |
+| Opera | >=117 | Ready | Windows, macOS, Linux, Android | ML-KEM (Kyber) | Based on Chromium, supports ML-KEM-768 hybrid key exchange following upstream implementation. |
+| Mozilla Firefox Desktop | >=132 | Ready | Windows, macOS, Linux | mlkem768x25519 / X25519MLKEM768 | Enabled by default for TLS 1.3 on desktop starting in Firefox 132. References: https://www.mozilla.org/en-US/firefox/132.0/releasenotes/ and https://bugzilla.mozilla.org/show_bug.cgi?id=1919097 |
+| Mozilla Firefox Android | >=145 | Ready | Android | mlkem768x25519 / X25519MLKEM768 | Firefox for Android 145 added ML-KEM support for TLS 1.3 and HTTP/3. Reference: https://www.mozilla.org/en-US/firefox/android/145.0/releasenotes/ |
 | Mozilla Firefox iOS | Unknown / Limited | Needs Validation | iOS | Unknown | Firefox on iOS relies on Apple WebKit networking constraints, so PQC readiness should be validated separately. |
-| Apple Safari | N/A | 🔴 Not Supported | macOS, iOS, iPadOS | None | Safari does not yet have announced PQC support in TLS. Apple has not publicly disclosed PQC implementation timeline. |
+| Apple Safari | N/A | Not Supported | macOS, iOS, iPadOS | None | Safari does not yet have announced PQC support in TLS. Apple has not publicly disclosed PQC implementation timeline. |
 
-Status: 🟢 Ready / 🟡 In Progress / 🔴 Not Started
+Status: Ready / In Progress / Not Started
 
 ## How to Contribute
+
 1. Fork this repo.
 2. Update the table above with new information or edits.
 3. Submit a Pull Request with the tag `[PQC-Readiness]`.
 
 ## Guidance
-* All linked information should point to an official repository or technical documentation. If you provide a link to a press releases or product page, you will be asked to provide a different link.
+
+* All linked information should point to an official repository or technical documentation.
 * For browsers, please include version numbers where PQC support was introduced.
 * Focus on TLS/HTTPS connection security rather than other cryptographic features.

--- a/web-browsers.md
+++ b/web-browsers.md
@@ -12,8 +12,8 @@ These trackers are a crowdsourced effort; please contribute by updating the stat
 | Microsoft Edge | >=131 | 🟢 Ready | Windows, macOS, Linux, Android, iOS | ML-KEM (Kyber) | Based on Chromium, follows Chrome's PQC implementation timeline. Enabled ML-KEM-768 hybrid key exchange in version 131. |
 | Brave | >=1.73 | 🟢 Ready | Windows, macOS, Linux, Android, iOS | ML-KEM (Kyber) | Based on Chromium, enabled ML-KEM-768 hybrid key exchange. Follows upstream Chromium PQC implementation. |
 | Opera | >=117 | 🟢 Ready | Windows, macOS, Linux, Android | ML-KEM (Kyber) | Based on Chromium, supports ML-KEM-768 hybrid key exchange following upstream implementation. |
-| Mozilla Firefox Desktop | >=132 | Ready | Windows, macOS, Linux | mlkem768x25519 / X25519MLKEM768 | Enabled by default for TLS 1.3 on desktop starting in Firefox 132. References: https://www.mozilla.org/en-US/firefox/132.0/releasenotes/ and https://bugzilla.mozilla.org/show_bug.cgi?id=1919097 |
-| Mozilla Firefox Android | >=145 | Ready | Android | mlkem768x25519 / X25519MLKEM768 | Firefox for Android 145 added ML-KEM support for TLS 1.3 and HTTP/3. Reference: https://www.mozilla.org/en-US/firefox/android/145.0/releasenotes/ |
+| Mozilla Firefox Desktop | >=132 | 🟢 Ready | Windows, macOS, Linux | mlkem768x25519 / X25519MLKEM768 | Enabled by default for TLS 1.3 on desktop starting in Firefox 132. References: https://www.mozilla.org/en-US/firefox/132.0/releasenotes/ and https://bugzilla.mozilla.org/show_bug.cgi?id=1919097 |
+| Mozilla Firefox Android | >=145 | 🟢 Ready | Android | mlkem768x25519 / X25519MLKEM768 | Firefox for Android 145 added ML-KEM support for TLS 1.3 and HTTP/3. Reference: https://www.mozilla.org/en-US/firefox/android/145.0/releasenotes/ |
 | Mozilla Firefox iOS | Unknown / Limited | Needs Validation | iOS | Unknown | Firefox on iOS relies on Apple WebKit networking constraints, so PQC readiness should be validated separately. |
 | Apple Safari | N/A | 🔴 Not Supported | macOS, iOS, iPadOS | None | Safari does not yet have announced PQC support in TLS. Apple has not publicly disclosed PQC implementation timeline. |
 


### PR DESCRIPTION
## Summary

This update refines the web browser PQC readiness tracker by:

* Correcting Firefox PQC support information
* Replacing an unrelated Bugzilla reference
* Separating Firefox Desktop, Android, and iOS behavior
* Clarifying browser support wording and validation states
* Improving consistency of ML-KEM hybrid terminology

## Notes

Firefox desktop support reflects TLS 1.3 ML-KEM hybrid support enabled by default beginning in Firefox 132.

Firefox Android support is tracked separately because implementation timelines differ by platform.

Some browser entries were also adjusted to avoid overstating unsupported or unverified states where public vendor guidance is limited.
