### PR TITLE
Start Tracking WG meeting record for June 18, 2026

### DIFF
--- a/meeting-minutes/2026/2026-06-18-tracking-wg.md
+++ b/meeting-minutes/2026/2026-06-18-tracking-wg.md
@@ -1,0 +1,104 @@
+layout: default
+title: 2026-06-18 Tracking WG Meeting Record
+parent: 2026
+grand_parent: Meeting Minutes
+---
+
+# Post-Quantum Cryptography Alliance - Readiness Tracking Working Group Meeting 18 June, 2026
+[**View Recording**]<pending>
+*Recordings are also available on your [Open Profile](https://openprofile.dev/my-meetings) page under Past Meetings*  
+[**Join the meeting**](https://zoom-lfx.platform.linuxfoundation.org/meeting/92180236021?password%3Db0389cf7-46b4-4b12-8960-743736597cff&sa=D&source=calendar&ust=1779060340269221&usg=AOvVaw0xXXgXsS7I24ZkWvbZYInS)  
+[**PQCA Meeting Calendar**](https://pqca.org/calendar/)  
+[**Discord Server**](https://discord.pqca.org)
+
+---
+
+### **Antitrust Policy Notice**
+
+Linux Foundation meetings involve participation by industry competitors, and it is the intention of the Linux Foundation to conduct all of its activities in
+accordance with applicable antitrust and competition laws. It is therefore extremely important that attendees adhere to meeting agendas, and be aware of,
+and not participate in, any activities that are prohibited under applicable US state, federal or foreign antitrust and competition laws. Examples of types
+of actions that are prohibited at Linux Foundation meetings and in connection with Linux Foundation activities are described in the Linux Foundation
+Antitrust Policy available at [linuxfoundation.org/antitrust-policy](https://linuxfoundation.org/antitrust-policy). If you have questions about these
+matters, please contact your company counsel, or if you are a member of the Linux Foundation, feel free to contact Andrew Updegrove of the firm of Gesmer
+Updegrove LLP, which provides legal counsel to the Linux Foundation.
+
+---
+
+## Attendance (_Alphabetical by 1st name_)
+* [] Aditya Koranga, NgKore \[TAC Chair\]
+* [] Aleksei Odinokov, PQC Ready
+* [] Andy Warner, Google \[Tracking WG Chair\]
+* [] Avinash Nagadi
+* [] Basil Hess, IBM
+* [] Bill Turner, PKI Consortium
+* [] Christian Pfister, LGT Bank
+* [] Daniel Speciale, QInsight
+* [] Guncha Malik, IBM
+* [] Hart Montgomery, Linux Foundation
+* [] Ian Palmer, GCIB
+* [] Iyán Méndez Veiga, HSLU / ETH Zurich
+* [] Jane Ginn, Cyber Threat Intelligence Network
+* [] Jeyaganesh Narayanaswamy, AIB (Ireland)
+* [] Kyle Loree, Quantum Algorithms Institute
+* [] Marla Sumner, UT Austin
+* [] Masab Iqbal, Multiverse Computing
+* [] Mike Novak
+* [] Mukul Kulkarni, Technology Innovation Institute (Abu Dhabi)
+* [] Neha Gupta, University of Surrey
+* [] Salvatore Migliaccio, Namirial
+* [] Shubham Kumar, NgKore
+* [] Sogo Pierre Sanon, Hydro Quebec Research Institute
+* [] Thomas Pöppelmann, Google
+
+---
+# Meeting Agenda
+
+- **Overview of the WG**
+
+ - **Goal**: Provide a reliable source of information about the Post-Quantum Cryptography readiness of common devices, libraies, operating systems and software via a community driven effort welcoming submission and updates from any interested party. To succeed, active community participation is needed. 
+ - Approved by the TAC: https://github.com/PQCA/TAC/issues/139
+ - Mailing List: https://lists.pqca.org/g/wg-readiness-tracking
+ - GitHub Repository: https://github.com/PQCA/wg-readiness-tracking
+ - Meeting Cadence: Every 2 weeks beginning May 21, 2026 [meeting link] - Open to the public
+
+---
+
+# Discussion & Updates
+
+### **Introductions**
+
+Have new attendees provide a quick intro (name, company / org, why they are interested in the Tracking WG)
+
+* <pending>
+
+---
+
+### **Administrative**
+
+  - Do we feel ready to shift to two person reviews or should we push that change out to August?
+  - Are there any vounteers to review the working group charter?
+
+---
+
+### **Review of open Issues and PRs**
+
+  - [Open Issues](https://github.com/PQCA/wg-readiness-tracking/issues)
+  - [Open PRs](https://github.com/PQCA/wg-readiness-tracking/pulls)
+  - **<pending - ? were reviewed.>** 
+
+---
+
+### **Next Steps / Action Items**
+
+| Action Item | Owner | Status / Due Date |
+|--------------|--------|------------------|
+| Add contributions via PRs | All interested parties | Ongoing | 
+| Review PRs | All interested parties | Ongoing | 
+| Commit PRs we agreed on in the 2026-06-04 meeting | Andy Warner | Done |
+| Send a reminder ~48 hours before future meetings | Andy Warner | Ongoing |
+| Send a PR to add Aditya and Marla | Andy Warner | Done |
+
+---
+
+**Adjourned:** 09:29 am PT.

--- a/meeting-minutes/2026/2026-06-18-tracking-wg.md
+++ b/meeting-minutes/2026/2026-06-18-tracking-wg.md
@@ -5,7 +5,7 @@ grand_parent: Meeting Minutes
 ---
 
 # Post-Quantum Cryptography Alliance - Readiness Tracking Working Group Meeting 18 June, 2026
-[**View Recording**]<pending>
+[**View Recording**](https://zoom.us/rec/share/7FhIAbCXEWis8_rQZfa_LT5pF7UV7cDYyf180JR6hMxddNNim7v7W5Ph4ue9BCQ_.yPJIBkY0sf3gVpg2)
 *Recordings are also available on your [Open Profile](https://openprofile.dev/my-meetings) page under Past Meetings*  
 [**Join the meeting**](https://zoom-lfx.platform.linuxfoundation.org/meeting/92180236021?password%3Db0389cf7-46b4-4b12-8960-743736597cff&sa=D&source=calendar&ust=1779060340269221&usg=AOvVaw0xXXgXsS7I24ZkWvbZYInS)  
 [**PQCA Meeting Calendar**](https://pqca.org/calendar/)  
@@ -26,30 +26,30 @@ Updegrove LLP, which provides legal counsel to the Linux Foundation.
 ---
 
 ## Attendance (_Alphabetical by 1st name_)
-* [] Aditya Koranga, NgKore \[TAC Chair\]
-* [] Aleksei Odinokov, PQC Ready
-* [] Andy Warner, Google \[Tracking WG Chair\]
+* [x] Aditya Koranga, NgKore \[TAC Chair\]
+* [x] Aleksei Odinokov, PQC Ready
+* [x] Andy Warner, Google \[Tracking WG Chair\]
 * [] Avinash Nagadi
 * [] Basil Hess, IBM
 * [] Bill Turner, PKI Consortium
 * [] Christian Pfister, LGT Bank
 * [] Daniel Speciale, QInsight
 * [] Guncha Malik, IBM
-* [] Hart Montgomery, Linux Foundation
-* [] Ian Palmer, GCIB
+* [x] Hart Montgomery, Linux Foundation
+* [x] Ian Palmer, GCIB
 * [] Iyán Méndez Veiga, HSLU / ETH Zurich
-* [] Jane Ginn, Cyber Threat Intelligence Network
+* [x] Jane Ginn, Cyber Threat Intelligence Network
 * [] Jeyaganesh Narayanaswamy, AIB (Ireland)
 * [] Kyle Loree, Quantum Algorithms Institute
-* [] Marla Sumner, UT Austin
+* [x] Marla Sumner, UT Austin
 * [] Masab Iqbal, Multiverse Computing
-* [] Mike Novak
+* [x] Mike Novak
 * [] Mukul Kulkarni, Technology Innovation Institute (Abu Dhabi)
 * [] Neha Gupta, University of Surrey
 * [] Salvatore Migliaccio, Namirial
 * [] Shubham Kumar, NgKore
-* [] Sogo Pierre Sanon, Hydro Quebec Research Institute
-* [] Thomas Pöppelmann, Google
+* [x] Sogo Pierre Sanon, Hydro Quebec Research Institute
+* [x] Thomas Pöppelmann, Google
 
 ---
 # Meeting Agenda

--- a/meeting-minutes/2026/2026-06-18-tracking-wg.md
+++ b/meeting-minutes/2026/2026-06-18-tracking-wg.md
@@ -77,7 +77,9 @@ Have new attendees provide a quick intro (name, company / org, why they are inte
 ### **Administrative**
 
   - Do we feel ready to shift to two person reviews or should we push that change out to August?
+    - There was agreement to wait until August and re-evaluate 
   - Are there any vounteers to review the working group charter?
+    - Aditya and Alecksi volunteered 
 
 ---
 
@@ -85,7 +87,19 @@ Have new attendees provide a quick intro (name, company / org, why they are inte
 
   - [Open Issues](https://github.com/PQCA/wg-readiness-tracking/issues)
   - [Open PRs](https://github.com/PQCA/wg-readiness-tracking/pulls)
-  - **<pending - ? were reviewed.>** 
+  - **<pending - ? were reviewed.>**
+
+### **Open discussion**
+
+  - Andy proposed reviewing HSM readiness at the next working group meeting
+  - Aditya suggested that we standardize on "Not supported" and stop using "Not started"
+    - There was agremeent to adopt this standard and Aditya volunteered to send a PR
+  - Aditya raised the question of how we best reflect state when key encapsulation and signing are in different readiness states
+    - We agreed on having seperate entries for each when they differ and merging them after both have been supported for a year with notes explaining when each one was ready. 
+  - It was suggested that Network Devices and Semiconductors (including BIOS and TPMs) would be good next areas to explore
+    - For network devices it will probably make sense to carve them up by vendor given the volume of devices
+  -  There was brief discussion of whether tracking data sets and test tools made sense
+    - There was agreement it may make sense in the future and such contributions would be accepted, but it is not an early priority for the WG. 
 
 ---
 


### PR DESCRIPTION
Create a new meeting record for the Tracking WG to reflect the new date and attendance. Adjusted agenda items and action items based on the latest meeting discussions.