### PR TITLE
Add meeting minutes for Tracking WG on 2026-08-13

### DIFF
--- a/meeting-minutes/2026/2026-08-13-tracking-wg.md
+++ b/meeting-minutes/2026/2026-08-13-tracking-wg.md
@@ -41,7 +41,7 @@ Updegrove LLP, which provides legal counsel to the Linux Foundation.
 * [] Iyán Méndez Veiga, HSLU / ETH Zurich
 * [] Jane Ginn, Cyber Threat Intelligence Network
 * [] Jeyaganesh Narayanaswamy, AIB (Ireland)
-* [X] Leila
+* [X] Leila Taghizadeh, Allianz
 * [] Kyle Loree, Quantum Algorithms Institute
 * [] Marla Sumner, UT Austin
 * [] Masab Iqbal, Multiverse Computing

--- a/meeting-minutes/2026/2026-08-13-tracking-wg.md
+++ b/meeting-minutes/2026/2026-08-13-tracking-wg.md
@@ -1,0 +1,111 @@
+layout: default
+title: 2026-08-13 Tracking WG Meeting Record
+parent: 2026
+grand_parent: Meeting Minutes
+---
+
+# Post-Quantum Cryptography Alliance - Readiness Tracking Working Group Meeting 13 August, 2026
+[**View Recording**]<pending>
+*Recordings are also available on your [Open Profile](https://openprofile.dev/my-meetings) page under Past Meetings*  
+[**Join the meeting**](https://zoom-lfx.platform.linuxfoundation.org/meeting/92180236021?password%3Db0389cf7-46b4-4b12-8960-743736597cff&sa=D&source=calendar&ust=1779060340269221&usg=AOvVaw0xXXgXsS7I24ZkWvbZYInS)  
+[**PQCA Meeting Calendar**](https://pqca.org/calendar/)  
+[**Discord Server**](https://discord.pqca.org)
+
+---
+
+### **Antitrust Policy Notice**
+
+Linux Foundation meetings involve participation by industry competitors, and it is the intention of the Linux Foundation to conduct all of its activities in
+accordance with applicable antitrust and competition laws. It is therefore extremely important that attendees adhere to meeting agendas, and be aware of,
+and not participate in, any activities that are prohibited under applicable US state, federal or foreign antitrust and competition laws. Examples of types
+of actions that are prohibited at Linux Foundation meetings and in connection with Linux Foundation activities are described in the Linux Foundation
+Antitrust Policy available at [linuxfoundation.org/antitrust-policy](https://linuxfoundation.org/antitrust-policy). If you have questions about these
+matters, please contact your company counsel, or if you are a member of the Linux Foundation, feel free to contact Andrew Updegrove of the firm of Gesmer
+Updegrove LLP, which provides legal counsel to the Linux Foundation.
+
+---
+
+## Attendance (_Alphabetical by 1st name_)
+* [] Aditya Koranga, NgKore \[TAC Chair\]
+* [] Alexey Odinokov, PQC Ready
+* [] Andy Warner, Google \[Tracking WG Chair\]
+* [] Avinash Nagadi
+* [] Basil Hess, IBM
+* [] Bill Turner, PKI Consortium
+* [] Christian Pfister, LGT Bank
+* [] Daniel Speciale, QInsight
+* [] Ganesh Mallya, AppViewX
+* [] Guncha Malik, IBM
+* [] Hart Montgomery, Linux Foundation
+* [] Ian Palmer, GCIB
+* [] Iyán Méndez Veiga, HSLU / ETH Zurich
+* [] Jane Ginn, Cyber Threat Intelligence Network
+* [] Jeyaganesh Narayanaswamy, AIB (Ireland)
+* [] Kyle Loree, Quantum Algorithms Institute
+* [] Marla Sumner, UT Austin
+* [] Masab Iqbal, Multiverse Computing
+* [] Michael Howard, Microsoft
+* [] Mike Novak
+* [] Mukul Kulkarni, Technology Innovation Institute (Abu Dhabi)
+* [] Neha Gupta, University of Surrey
+* [] Salvatore Migliaccio, Namirial
+* [] Shubham Kumar, NgKore
+* [] Sogo Pierre Sanon, Hydro Quebec Research Institute
+* [] Thomas Pöppelmann, Google
+* [] Tushar Shring, Volkswagen
+
+---
+# Meeting Agenda
+
+- **Overview of the WG**
+
+ - **Goal**: Provide a reliable source of information about the Post-Quantum Cryptography readiness of common devices, libraies, operating systems and software via a community driven effort welcoming submission and updates from any interested party. To succeed, active community participation is needed. 
+ - Approved by the TAC: https://github.com/PQCA/TAC/issues/139
+ - Mailing List: https://lists.pqca.org/g/wg-readiness-tracking
+ - GitHub Repository: https://github.com/PQCA/wg-readiness-tracking
+ - Meeting Cadence: Every 2 weeks beginning May 21, 2026 [meeting link] - Open to the public
+
+---
+
+# Discussion & Updates
+
+### **Introductions**
+
+Have new attendees provide a quick intro (name, company / org, why they are interested in the Tracking WG)
+
+- ?
+  
+---
+
+### **Administrative**
+
+  - ?
+
+---
+
+### **Review of open Issues and PRs**
+
+  - [Open Issues](https://github.com/PQCA/wg-readiness-tracking/issues)
+    - No 'new' issues.
+  - [Open PRs](https://github.com/PQCA/wg-readiness-tracking/pulls)
+    -  5 open PRs. Some small adjustments from before and one new contribution
+
+### **Open discussion**
+
+  - 
+
+---
+
+### **Next Steps / Action Items**
+
+| Action Item | Owner | Status / Due Date |
+|--------------|--------|------------------|
+| Add contributions via PRs | All interested parties | Ongoing | 
+| Review PRs | All interested parties | Ongoing | 
+| Commit PRs we agreed on in the 2026-08-13 meeting | Andy Warner | Done |
+| Send a reminder ~48 hours before future meetings | Andy Warner | Ongoing |
+| Review the WG Charter | Aditya & Aleksi | Pending |
+
+---
+
+**Adjourned:** 09:29 am PT.

--- a/meeting-minutes/2026/2026-08-13-tracking-wg.md
+++ b/meeting-minutes/2026/2026-08-13-tracking-wg.md
@@ -5,7 +5,7 @@ grand_parent: Meeting Minutes
 ---
 
 # Post-Quantum Cryptography Alliance - Readiness Tracking Working Group Meeting 13 August, 2026
-[**View Recording**]<pending>
+[**View Recording**](https://zoom.us/rec/share/Ddtc9cqKjPluzd3uaAZX-dqFPZphMqVafI0WSfJnuAClFtFD8vql1JMtx2VcbYYH.sT0hO6Mp3JBkk3p-)
 *Recordings are also available on your [Open Profile](https://openprofile.dev/my-meetings) page under Past Meetings*  
 [**Join the meeting**](https://zoom-lfx.platform.linuxfoundation.org/meeting/92180236021?password%3Db0389cf7-46b4-4b12-8960-743736597cff&sa=D&source=calendar&ust=1779060340269221&usg=AOvVaw0xXXgXsS7I24ZkWvbZYInS)  
 [**PQCA Meeting Calendar**](https://pqca.org/calendar/)  
@@ -28,28 +28,29 @@ Updegrove LLP, which provides legal counsel to the Linux Foundation.
 ## Attendance (_Alphabetical by 1st name_)
 * [] Aditya Koranga, NgKore \[TAC Chair\]
 * [] Alexey Odinokov, PQC Ready
-* [] Andy Warner, Google \[Tracking WG Chair\]
+* [X] Andy Warner, Google \[Tracking WG Chair\]
 * [] Avinash Nagadi
 * [] Basil Hess, IBM
 * [] Bill Turner, PKI Consortium
 * [] Christian Pfister, LGT Bank
 * [] Daniel Speciale, QInsight
-* [] Ganesh Mallya, AppViewX
+* [X] Ganesh Mallya, AppViewX
 * [] Guncha Malik, IBM
-* [] Hart Montgomery, Linux Foundation
+* [X] Hart Montgomery, Linux Foundation
 * [] Ian Palmer, GCIB
 * [] Iyán Méndez Veiga, HSLU / ETH Zurich
 * [] Jane Ginn, Cyber Threat Intelligence Network
 * [] Jeyaganesh Narayanaswamy, AIB (Ireland)
+* [X] Leila
 * [] Kyle Loree, Quantum Algorithms Institute
 * [] Marla Sumner, UT Austin
 * [] Masab Iqbal, Multiverse Computing
 * [] Michael Howard, Microsoft
 * [] Mike Novak
-* [] Mukul Kulkarni, Technology Innovation Institute (Abu Dhabi)
+* [X] Mukul Kulkarni, Technology Innovation Institute (Abu Dhabi)
 * [] Neha Gupta, University of Surrey
 * [] Salvatore Migliaccio, Namirial
-* [] Shubham Kumar, NgKore
+* [X] Shubham Kumar, NgKore
 * [] Sogo Pierre Sanon, Hydro Quebec Research Institute
 * [] Thomas Pöppelmann, Google
 * [] Tushar Shring, Volkswagen
@@ -59,7 +60,7 @@ Updegrove LLP, which provides legal counsel to the Linux Foundation.
 
 - **Overview of the WG**
 
- - **Goal**: Provide a reliable source of information about the Post-Quantum Cryptography readiness of common devices, libraies, operating systems and software via a community driven effort welcoming submission and updates from any interested party. To succeed, active community participation is needed. 
+ - **Goal**: Provide a reliable source of information about the Post-Quantum Cryptography readiness of common devices, libraries, operating systems and software via a community driven effort welcoming submission and updates from any interested party. To succeed, active community participation is needed. 
  - Approved by the TAC: https://github.com/PQCA/TAC/issues/139
  - Mailing List: https://lists.pqca.org/g/wg-readiness-tracking
  - GitHub Repository: https://github.com/PQCA/wg-readiness-tracking


### PR DESCRIPTION
Documented the minutes for the Tracking WG meeting held on August 13, 2026, including attendance, agenda, discussions, and action items.