### PR TITLE
Add TPM PQC readiness tracking page

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ approving information using the [Cryptographic Library tracker](cryptography.md)
 * [Cryptographic Libraries](cryptography.md) - Tracking PQC readiness for cryptography libraries and tools
 * [HSMs](hsm.md) - Hardware Security Modules
 * [Web Browsers](web-browsers.md) - Tracking PQC support in major web browsers
+* [TPMs](tpm.md) - Trusted Platform Modules
 
 ## Other Data Sources
 

--- a/tpm.md
+++ b/tpm.md
@@ -26,7 +26,7 @@ as of PTP 1.07. TCG has defined two transition designations:
 | Microchip ATTPM20P | TCG FW rev116 | 🔴 Not Supported | PC Client (PTP 1.3) | None | No PQC support identified. |
 | Nuvoton NPCT7xx | v1.16/1.38 | 🔴 Not Supported | PC Client (PTP 1.03) | None | No PQC support identified. |
 | SEALSQ QVault TPM 183 | TPR1003B (Preliminary) | 🔴 Not Supported | PC Client (PTP 1.06) | None | ML-DSA used for firmware update signing only, not available for application TPM operations. Per [QVault TPM 183 Technical Datasheet](https://www.sealsq.com/hubfs/TPR1003B_10Aug26.pdf?hsLang=en). |
-| SEALSQ QVault TPM 185 | TPR1026A (Preliminary) | 🟢 Ready | PC Client (PTP 1.07) | ML-KEM/ML-DSA | ML-KEM and ML-DSA mandatory per [QVault TPM 185 Technical Datasheet](https://www.sealsq.com/hubfs/Data%20Sheets/QVaultTPM_185_Datasheet.pdf). FIPS 140-3 and TCG certification processes underway. Preliminary datasheet. |
+| SEALSQ QVault TPM 185 | TPR1026A (Preliminary) | 🟡 In Progress | PC Client (PTP 1.07) | ML-KEM/ML-DSA | ML-KEM and ML-DSA mandatory per [QVault TPM 185 Technical Datasheet](https://www.sealsq.com/hubfs/Data%20Sheets/QVaultTPM_185_Datasheet.pdf). FIPS 140-3 and TCG certification processes underway. Preliminary datasheet. |
 | STMicroelectronics ST33KTPM2X | v1.59 errata 1.5 | 🔴 Not Supported | PC Client (PTP 1.06) | None | Firmware update signed with LMS (SP800-208) per downloadable databrief but no PQC algorithm support for application cryptographic operations. |
 
 Status: 🟢 Ready / 🟡 In Progress / 🔴 Not Supported

--- a/tpm.md
+++ b/tpm.md
@@ -1,0 +1,28 @@
+# PQC Readiness Tracker: Trusted Platform Modules (TPMs)
+
+This page tracks the state of Post-Quantum Cryptography (PQC) readiness 
+for Trusted Platform Modules (TPMs).
+
+These trackers are a crowdsourced effort; please contribute by adding 
+details about items you maintain or have reliable knowledge of.
+
+## Background
+
+The [TCG PC Client Platform TPM Profile (PTP) 1.07](https://trustedcomputinggroup.org/wp-content/uploads/PC-Client-Specific-Platform-TPM-Profile-for-TPM-2p0-v1p07_Pub.pdf) 
+defines the baseline for PQC-ready TPMs. ML-KEM and ML-DSA are mandatory 
+as of PTP 1.07. TCG has defined two transition designations:
+
+- **TCG PQC-ready TPM** — implements PTP 1.07
+- **TCG PQC-upgradable TPM** — does not currently support PTP 1.07 but 
+  can be upgraded via firmware
+
+TCG plans to certify TPMs against PTP 1.07. Details on the certification 
+program are forthcoming. See [TCG guidance on PQC-ready TPMs](https://trustedcomputinggroup.org).
+
+## Trusted Platform Modules
+
+**_Seed data — not complete or fully vetted._**
+
+| Vendor / Model | Firmware Version | PQC Status | TCG Designation | Supported PQC Algorithms | Notes |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| Example TPM | 1.0 | 🔴 Not Supported | N/A | None | Link to source |

--- a/tpm.md
+++ b/tpm.md
@@ -19,15 +19,15 @@ as of PTP 1.07. TCG has defined two transition designations:
 
 ## TPM Status Registry
 
-| TPM Model | Version | Status | Supported PQC Algorithms | Notes / Trackers |
-| :--- | :--- | :--- | :--- | :--- |
-| [Example TPM] | 1.0 | 🔴 Not Supported |  None | Link to issue/PR |
-| Microchip ATTPM20P | TCG FW rev116 | 🔴 Not Supported |  None | TPM 2.0 discrete module. No PQC support indicated. Verify active product status. |
-| Infineon OPTIGA 9672/9673 | FW 15.xx | 🔴 Not Supported  None | PQC-protected firmware update mechanism using XMSS signatures. This protects the firmware update channel only — no PQC algorithm support for application cryptographic operations. Awaiting PTP 1.07 compliant firmware. |
-| Nuvoton NPCT7xx | ? | 🔴 Not Supported | None | No PQC support in current firmware. Awaiting PTP 1.07 compliant firmware.|
-| SEALSQ QVault TPM | ? | 🟡 In Progress | ML-DSA, ML-KEM | Samples available. Technical documentation needed to confirm algorithm details and version. |
-| STMicroelectronics ST33 | ? | 🔴 Not Supported |  None | No PQC support in current firmware. Awaiting PTP 1.07 compliant firmware. |
-
+| TPM Model | Version | Status | TCG Profile | Supported PQC Algorithms | Notes / Trackers |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| [Example TPM] | 1.0 | 🔴 Not Supported | N/A | None | Link to issue/PR |
+| Infineon OPTIGA TPM SLB 9672/9673 | FW 15.xx | 🔴 Not Supported | PC Client (PTP 1.05) | None | PQC-protected firmware update mechanism using XMSS signatures. This protects the firmware update channel only. No PQC algorithm support for application cryptographic operations. Awaiting PTP 1.07 compliant firmware. Per [OPTIGA TPM SLB 9672 FW15 product page](https://www.infineon.com/part/OPTIGA-TPM-SLB-9672-FW15). |
+| Microchip ATTPM20P | TCG FW rev116 | 🔴 Not Supported | PC Client (PTP 1.3) | None | No PQC support. Implements PTP 1.3 per [ATTPM20P online documentation](https://onlinedocs.microchip.com/oxy/GUID-47B5637E-C743-4D21-9F4B-2353A2074F19-en-US-3/GUID-5D5AEE76-B710-4D49-A664-EF2D4D125CF4.html). Awaiting PTP 1.07 compliant firmware. |
+| Nuvoton NPCT7xx | v1.16/1.38 | 🔴 Not Supported | PC Client (PTP 1.03) | None | No PQC support in current firmware. Awaiting PTP 1.07 compliant firmware. Per [Nuvoton NPCT75x product comparison](https://www.nuvoton.com/products/security-ics/trusted-platform-module/npct75x/). |
+| SEALSQ QVault TPM 183 | TPR1003B (Preliminary) | 🔴 Not Supported | PC Client (PTP 1.06) | None | ML-DSA used for firmware update signing only, not available for application TPM operations. Per [QVault TPM 183 Technical Datasheet](https://www.sealsq.com/hubfs/QVault%20TPM%20V8.pdf). Awaiting PTP 1.07 compliant firmware. |
+| SEALSQ QVault TPM 185 | TPR1026A (Preliminary) | 🟢 Ready | PC Client (PTP 1.07) | ML-KEM/ML-DSA | ML-KEM and ML-DSA mandatory per [QVault TPM 185 Technical Datasheet](https://www.sealsq.com/hubfs/Data%20Sheets/QVaultTPM_185_Datasheet.pdf). FIPS 140-3 and TCG certification processes underway. Preliminary datasheet. |
+| STMicroelectronics ST33KTPM2X | v1.59 errata 1.5 | 🔴 Not Supported | PC Client (PTP 1.06) | None | Firmware update signed with LMS (SP800-208) but no PQC algorithm support for application cryptographic operations. Awaiting PTP 1.07 compliant firmware. Per [ST33KTPM2X product page](https://www.st.com/en/secure-mcus/st33ktpm2x.html). |
 
 Status: 🟢 Ready / 🟡 In Progress / 🔴 Not Supported
 
@@ -50,4 +50,4 @@ Status: 🟢 Ready / 🟡 In Progress / 🔴 Not Supported
 * Include firmware version numbers where PQC support was introduced.
 * Distinguish between PQC support for application cryptographic operations and PQC-protected firmware update mechanisms — these are not the same thing.
 * Note the TCG designation (PQC-ready or PQC-upgradable) where known, per [TCG guidance](https://trustedcomputinggroup.org/wp-content/uploads/PC-Client-Specific-Platform-TPM-Profile-for-TPM-2p0-v1p07_Pub.pdf).
-* Focus on TPM 2.0 implementations. TPM 1.2 is end of life and should be noted as Not Supported without further detail.
+* Focus on TPM 2.0 implementations. TPM 1.2 has no path to PQC support.

--- a/tpm.md
+++ b/tpm.md
@@ -1,10 +1,12 @@
 # PQC Readiness Tracker: Trusted Platform Modules (TPMs)
 
-This page tracks the state of Post-Quantum Cryptography (PQC) readiness 
-for Trusted Platform Modules (TPMs).
+**The Working Group has not settled on the final format, this version 
+is an early draft intended to solicit input.**
 
-These trackers are a crowdsourced effort; please contribute by adding 
-details about items you maintain or have reliable knowledge of.
+These pages track the state of Post-Quantum Cryptography (PQC) readiness 
+for Trusted Platform Modules (TPMs). This is a crowdsourced effort; please 
+contribute by adding details about items you maintain or have reliable 
+knowledge of.
 
 ## Background
 
@@ -16,13 +18,36 @@ as of PTP 1.07. TCG has defined two transition designations:
 - **TCG PQC-upgradable TPM** — does not currently support PTP 1.07 but 
   can be upgraded via firmware
 
-TCG plans to certify TPMs against PTP 1.07. Details on the certification 
-program are forthcoming. See [TCG guidance on PQC-ready TPMs](https://trustedcomputinggroup.org).
+## TPM Status Registry
 
-## Trusted Platform Modules
-
-**_Seed data — not complete or fully vetted._**
-
-| Vendor / Model | Firmware Version | PQC Status | TCG Designation | Supported PQC Algorithms | Notes |
+| TPM Model | Version | Status | TCG Designation | Supported PQC Algorithms | Notes / Trackers |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| Example TPM | 1.0 | 🔴 Not Supported | N/A | None | Link to source |
+| [Example TPM] | 1.0 | 🔴 Not Supported | N/A | None | Link to issue/PR |
+
+Status: 🟢 Ready / 🟡 In Progress / 🔴 Not Supported
+
+## Readiness Criteria
+
+- **Inventory**: Does the TPM identify all non-PQC cryptographic dependencies?
+- **Algorithm Support**: Does it support NIST-standardized PQC algorithms?
+- **Agility**: Can the TPM switch between classical, hybrid, and PQC-only modes?
+
+### Status Definitions
+
+- 🟢 **Ready**: at least 1 NIST-standardized key exchange algorithm (e.g. ML-KEM) AND at least 1 NIST-standardized signature algorithm (e.g. ML-DSA) are supported.
+- 🟡 **In Progress**: only one of the two (key exchange OR signature) is supported, or support is in development/unreleased.
+- 🔴 **Not Supported**: neither is supported.
+
+## How to Contribute
+
+1. Fork this repo.
+2. Update the table above with new information or edits.
+3. Submit a Pull Request with the tag `[PQC-Readiness]`.
+
+## Guidance
+
+* All linked information should point to an official repository or technical documentation. If you provide a link to a press release or product page, you will be asked to provide a different link.
+* Include firmware version numbers where PQC support was introduced.
+* Distinguish between PQC support for application cryptographic operations and PQC-protected firmware update mechanisms — these are not the same thing.
+* Note the TCG designation (PQC-ready or PQC-upgradable) where known, per [TCG guidance](https://trustedcomputinggroup.org/wp-content/uploads/PC-Client-Specific-Platform-TPM-Profile-for-TPM-2p0-v1p07_Pub.pdf).
+* Focus on TPM 2.0 implementations. TPM 1.2 is end of life and should be noted as Not Supported without further detail.

--- a/tpm.md
+++ b/tpm.md
@@ -19,14 +19,14 @@ as of PTP 1.07. TCG has defined two transition designations:
 
 ## TPM Status Registry
 
-| TPM Model | Version | Status | TCG Designation | Supported PQC Algorithms | Notes / Trackers |
-| :--- | :--- | :--- | :--- | :--- | :--- |
-| [Example TPM] | 1.0 | 🔴 Not Supported | N/A | None | Link to issue/PR |
-| Microchip ATTPM20P | TCG FW rev116 | 🔴 Not Supported | ? | None | TPM 2.0 discrete module. No PQC support indicated. Verify active product status. |
-| Infineon OPTIGA TPM SLB 9672 | FW 15.xx | 🔴 Not Supported | ? | None | PQC-protected firmware update mechanism using XMSS signatures. This protects the firmware update channel only — no PQC algorithm support for application cryptographic operations. Awaiting PTP 1.07 compliant firmware. |
-| Nuvoton NPCT | ? | 🔴 Not Supported | ? | ? | Not Supported since PTP 1.07 just dropped today and no shipping firmware supports it yet |
-| SEALSQ QVault TPM | ? | 🔴 Not Supported | ? | ML-DSA, ML-KEM | Samples available. Technical documentation needed to confirm algorithm details and version. |
-| STMicroelectronics ST33 | ? | 🔴 Not Supported | ? | ? | Not Supported since PTP 1.07 just dropped today and no shipping firmware supports it yet |
+| TPM Model | Version | Status | Supported PQC Algorithms | Notes / Trackers |
+| :--- | :--- | :--- | :--- | :--- |
+| [Example TPM] | 1.0 | 🔴 Not Supported |  None | Link to issue/PR |
+| Microchip ATTPM20P | TCG FW rev116 | 🔴 Not Supported |  None | TPM 2.0 discrete module. No PQC support indicated. Verify active product status. |
+| Infineon OPTIGA 9672/9673 | FW 15.xx | 🔴 Not Supported  None | PQC-protected firmware update mechanism using XMSS signatures. This protects the firmware update channel only — no PQC algorithm support for application cryptographic operations. Awaiting PTP 1.07 compliant firmware. |
+| Nuvoton NPCT7xx | ? | 🔴 Not Supported | None | No PQC support in current firmware. Awaiting PTP 1.07 compliant firmware.|
+| SEALSQ QVault TPM | ? | 🟡 In Progress | ML-DSA, ML-KEM | Samples available. Technical documentation needed to confirm algorithm details and version. |
+| STMicroelectronics ST33 | ? | 🔴 Not Supported |  None | No PQC support in current firmware. Awaiting PTP 1.07 compliant firmware. |
 
 
 Status: 🟢 Ready / 🟡 In Progress / 🔴 Not Supported

--- a/tpm.md
+++ b/tpm.md
@@ -15,25 +15,22 @@ as of PTP 1.07. TCG has defined two transition designations:
 - **TCG PQC-upgradable TPM** — does not currently support PTP 1.07 but 
   can be upgraded via firmware
 
+**_Seed data for working out formatting and collected details. This is not complete or fully vetted._**
+
 ## TPM Status Registry
 
 | TPM Model | Version | Status | TCG Designation | Supported PQC Algorithms | Notes / Trackers |
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | [Example TPM] | 1.0 | 🔴 Not Supported | N/A | None | Link to issue/PR |
+| Microchip ATTPM20P | TCG FW rev116 | 🔴 Not Supported | ? | None | TPM 2.0 discrete module. No PQC support indicated. Verify active product status. |
 | Infineon OPTIGA TPM SLB 9672 | FW 15.xx | 🔴 Not Supported | ? | None | PQC-protected firmware update mechanism using XMSS signatures. This protects the firmware update channel only — no PQC algorithm support for application cryptographic operations. Awaiting PTP 1.07 compliant firmware. |
-| Infineon OPTIGA TPM SLB 9745 | ? | 🔴 Not Supported | ? | ? | |
-| Nuvoton NPCT | ? | ? | ? | ? | |
-| SEALSQ QVault TPM | ? | 🟡 In Progress | ? | ML-DSA, ML-KEM | Samples available. Technical documentation needed to confirm algorithm details and version. |
-| STMicroelectronics ST33 | ? | ? | ? | ? | |
+| Nuvoton NPCT | ? | 🔴 Not Supported | ? | ? | Not Supported since PTP 1.07 just dropped today and no shipping firmware supports it yet |
+| SEALSQ QVault TPM | ? | 🔴 Not Supported | ? | ML-DSA, ML-KEM | Samples available. Technical documentation needed to confirm algorithm details and version. |
+| STMicroelectronics ST33 | ? | 🔴 Not Supported | ? | ? | Not Supported since PTP 1.07 just dropped today and no shipping firmware supports it yet |
 
 
 Status: 🟢 Ready / 🟡 In Progress / 🔴 Not Supported
 
-## Readiness Criteria
-
-- **Inventory**: Does the TPM identify all non-PQC cryptographic dependencies?
-- **Algorithm Support**: Does it support NIST-standardized PQC algorithms?
-- **Agility**: Can the TPM switch between classical, hybrid, and PQC-only modes?
 
 ### Status Definitions
 

--- a/tpm.md
+++ b/tpm.md
@@ -22,12 +22,12 @@ as of PTP 1.07. TCG has defined two transition designations:
 | TPM Model | Version | Status | TCG Profile | Supported PQC Algorithms | Notes / Trackers |
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | [Example TPM] | 1.0 | 🔴 Not Supported | N/A | None | Link to issue/PR |
-| Infineon OPTIGA TPM SLB 9672/9673 | FW 15.xx | 🔴 Not Supported | PC Client (PTP 1.05) | None | PQC-protected firmware update mechanism using XMSS signatures. This protects the firmware update channel only. No PQC algorithm support for application cryptographic operations. Awaiting PTP 1.07 compliant firmware. Per [OPTIGA TPM SLB 9672 FW15 product page](https://www.infineon.com/part/OPTIGA-TPM-SLB-9672-FW15). |
-| Microchip ATTPM20P | TCG FW rev116 | 🔴 Not Supported | PC Client (PTP 1.3) | None | No PQC support. Implements PTP 1.3 per [ATTPM20P online documentation](https://onlinedocs.microchip.com/oxy/GUID-47B5637E-C743-4D21-9F4B-2353A2074F19-en-US-3/GUID-5D5AEE76-B710-4D49-A664-EF2D4D125CF4.html). Awaiting PTP 1.07 compliant firmware. |
-| Nuvoton NPCT7xx | v1.16/1.38 | 🔴 Not Supported | PC Client (PTP 1.03) | None | No PQC support in current firmware. Awaiting PTP 1.07 compliant firmware. Per [Nuvoton NPCT75x product comparison](https://www.nuvoton.com/products/security-ics/trusted-platform-module/npct75x/). |
-| SEALSQ QVault TPM 183 | TPR1003B (Preliminary) | 🔴 Not Supported | PC Client (PTP 1.06) | None | ML-DSA used for firmware update signing only, not available for application TPM operations. Per [QVault TPM 183 Technical Datasheet](https://www.sealsq.com/hubfs/QVault%20TPM%20V8.pdf). Awaiting PTP 1.07 compliant firmware. |
+| Infineon OPTIGA TPM SLB 9672/9673 | FW 15.xx | 🔴 Not Supported | PC Client (PTP 1.05) | None | PQC-protected firmware update mechanism using XMSS signatures. This protects the firmware update channel only. No PQC algorithm support for application cryptographic operations. [OPTIGA TPM SLB 9672 FW15 Datasheet](https://www.infineon.com/assets/row/public/documents/30/49/infineon-slb9672-tpm20-spi-fw15xx-ds-rev1-5-2024-11-13-datasheet-en.pdf). |
+| Microchip ATTPM20P | TCG FW rev116 | 🔴 Not Supported | PC Client (PTP 1.3) | None | No PQC support identified. |
+| Nuvoton NPCT7xx | v1.16/1.38 | 🔴 Not Supported | PC Client (PTP 1.03) | None | No PQC support identified. |
+| SEALSQ QVault TPM 183 | TPR1003B (Preliminary) | 🔴 Not Supported | PC Client (PTP 1.06) | None | ML-DSA used for firmware update signing only, not available for application TPM operations. Per [QVault TPM 183 Technical Datasheet](https://www.sealsq.com/hubfs/TPR1003B_10Aug26.pdf?hsLang=en). |
 | SEALSQ QVault TPM 185 | TPR1026A (Preliminary) | 🟢 Ready | PC Client (PTP 1.07) | ML-KEM/ML-DSA | ML-KEM and ML-DSA mandatory per [QVault TPM 185 Technical Datasheet](https://www.sealsq.com/hubfs/Data%20Sheets/QVaultTPM_185_Datasheet.pdf). FIPS 140-3 and TCG certification processes underway. Preliminary datasheet. |
-| STMicroelectronics ST33KTPM2X | v1.59 errata 1.5 | 🔴 Not Supported | PC Client (PTP 1.06) | None | Firmware update signed with LMS (SP800-208) but no PQC algorithm support for application cryptographic operations. Awaiting PTP 1.07 compliant firmware. Per [ST33KTPM2X product page](https://www.st.com/en/secure-mcus/st33ktpm2x.html). |
+| STMicroelectronics ST33KTPM2X | v1.59 errata 1.5 | 🔴 Not Supported | PC Client (PTP 1.06) | None | Firmware update signed with LMS (SP800-208) per downloadable databrief but no PQC algorithm support for application cryptographic operations. |
 
 Status: 🟢 Ready / 🟡 In Progress / 🔴 Not Supported
 

--- a/tpm.md
+++ b/tpm.md
@@ -1,8 +1,5 @@
 # PQC Readiness Tracker: Trusted Platform Modules (TPMs)
 
-**The Working Group has not settled on the final format, this version 
-is an early draft intended to solicit input.**
-
 These pages track the state of Post-Quantum Cryptography (PQC) readiness 
 for Trusted Platform Modules (TPMs). This is a crowdsourced effort; please 
 contribute by adding details about items you maintain or have reliable 
@@ -23,6 +20,12 @@ as of PTP 1.07. TCG has defined two transition designations:
 | TPM Model | Version | Status | TCG Designation | Supported PQC Algorithms | Notes / Trackers |
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | [Example TPM] | 1.0 | 🔴 Not Supported | N/A | None | Link to issue/PR |
+| Infineon OPTIGA TPM SLB 9672 | FW 15.xx | 🔴 Not Supported | ? | None | PQC-protected firmware update mechanism using XMSS signatures. This protects the firmware update channel only — no PQC algorithm support for application cryptographic operations. Awaiting PTP 1.07 compliant firmware. |
+| Infineon OPTIGA TPM SLB 9745 | ? | 🔴 Not Supported | ? | ? | |
+| Nuvoton NPCT | ? | ? | ? | ? | |
+| SEALSQ QVault TPM | ? | 🟡 In Progress | ? | ML-DSA, ML-KEM | Samples available. Technical documentation needed to confirm algorithm details and version. |
+| STMicroelectronics ST33 | ? | ? | ? | ? | |
+
 
 Status: 🟢 Ready / 🟡 In Progress / 🔴 Not Supported
 


### PR DESCRIPTION
Add TPM PQC readiness tracking page

This PR introduces a new tracking page for Trusted Platform Modules: 
- Created tpm.md with TPM PQC status - Tracked 6 TPMs: Infineon OPTIGA SLB 9672/9673, Microchip ATTPM20P, Nuvoton NPCT7xx, SEALSQ QVault TPM 183/185, STMicroelectronics ST33KTPM2X 
- SEALSQ QVault TPM 185 is the only entry currently Ready (PTP 1.07, preliminary datasheet) 
- All others Not Supported for application-level PQC; several have PQC-signed firmware update mechanisms only (XMSS/LMS), which is not tracked but noted. 
- Open question: where should CPU-integrated implementations (AMD fTPM, Intel PTT) be tracked, since they are not discrete TPMs

AI assisted and self verified. 

Signed-off-by: Marla Sumner <mmdsumner@gmail.com>